### PR TITLE
Outbound Transport Partitioning by Key tag

### DIFF
--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransport.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransport.java
@@ -56,6 +56,7 @@ class KafkaOutboundTransport extends OutboundTransportBase implements GeoEventAw
   private String topic;
   private int partitions;
   private int replicas;
+  private String partitionKeyTag;
 
   KafkaOutboundTransport(TransportDefinition definition) throws ComponentException {
     super(definition);
@@ -69,16 +70,38 @@ class KafkaOutboundTransport extends OutboundTransportBase implements GeoEventAw
   @Override
   public void receive(ByteBuffer byteBuffer, String channelId, GeoEvent geoEvent) {
     try {
-      if (geoEvent != null)
-      {
-        if (producer == null)
+      if (geoEvent != null) {
+        if (producer == null) {
           producer = new KafkaEventProducer(new EventDestination(topic), bootstrap);
-        producer.send(byteBuffer, geoEvent.hashCode());
+        }
+
+        Object partitionKey = null;
+
+        if(partitionKeyTag != null && !partitionKeyTag.isEmpty())
+        {
+          final int tagIndex = geoEvent.getGeoEventDefinition().getIndexOf(partitionKeyTag);
+
+          if (tagIndex >= 0) {
+            partitionKey = geoEvent.getField(tagIndex);
+          }
+          else
+          {
+            final String warnMsg = LOGGER.translate("NO_MATCHING_TAG_WARNING",
+                    geoEvent.getGeoEventDefinition()
+                            .getName(),
+                    partitionKeyTag);
+            LOGGER.warn(warnMsg);
+          }
+        }
+
+        producer.send(byteBuffer, partitionKey);
       }
     }
     catch (MessagingException e)
     {
-      ;
+      if(LOGGER.isDebugEnabled()) {
+        LOGGER.debug(e.getMessage(), e.getCause());
+      }
     }
   }
 
@@ -109,6 +132,7 @@ class KafkaOutboundTransport extends OutboundTransportBase implements GeoEventAw
     topic = getProperty("topic").getValueAsString();
     partitions = Converter.convertToInteger(getProperty("partitions").getValueAsString(), 1);
     replicas = Converter.convertToInteger(getProperty("replicas").getValueAsString(), 0);
+    partitionKeyTag = getProperty("partitionKeyTag").getValueAsString();
   }
 
   @Override
@@ -173,6 +197,30 @@ class KafkaOutboundTransport extends OutboundTransportBase implements GeoEventAw
   private class KafkaEventProducer extends KafkaComponentBase {
     private KafkaProducer<byte[], byte[]> producer;
 
+    private final Callback completionCallback = new Callback() {
+      @Override
+      public void onCompletion(RecordMetadata metadata, Exception e) {
+        if (e != null)
+        {
+          final String errorMsg = LOGGER.translate("KAFKA_SEND_FAILURE_ERROR", destination.getName(), e.getMessage());
+          LOGGER.error(errorMsg);
+          // offset = metadata.offset();
+          return;
+        }
+
+        if(LOGGER.isDebugEnabled())
+        {
+          final String debugMsg = LOGGER.translate("KAFKA_SENT_RECORD_DEBUG",
+                  metadata.topic(),
+                  metadata.partition(),
+                  metadata.offset(),
+                  metadata.serializedKeySize(),
+                  metadata.serializedValueSize());
+          LOGGER.debug(debugMsg);
+        }
+      }
+    };
+
     KafkaEventProducer(EventDestination destination, String bootstrap) {
       super(destination);
       // http://kafka.apache.org/documentation.html#producerconfigs
@@ -201,27 +249,31 @@ class KafkaOutboundTransport extends OutboundTransportBase implements GeoEventAw
       }
     }
 
-    public void send(final ByteBuffer bb, int h) throws MessagingException {
+    void send(final ByteBuffer bb, Object partitionKey) throws MessagingException {
       // wait to send messages if we are not connected
-      if (isConnected())
-      {
-        byte[] key = new byte[4];
-        key[3] = (byte) (h & 0xFF);
-        key[2] = (byte) ((h >> 8) & 0xFF);
-        key[1] = (byte) ((h >> 16) & 0xFF);
-        key[0] = (byte) ((h >> 24) & 0xFF);
-        ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[], byte[]>(destination.getName(), key, bb.array());
-        producer.send(record, new Callback() {
-          @Override
-          public void onCompletion(RecordMetadata metadata, Exception e) {
-            if (e != null) {
-              String errorMsg = LOGGER.translate("KAFKA_SEND_FAILURE_ERROR", destination.getName(), e.getMessage());
-              LOGGER.error(errorMsg);
-            }
-            else
-              LOGGER.debug("The offset of the record we just sent is: " + metadata.offset());
-          }
-        });
+      if (isConnected()) {
+        final ProducerRecord<byte[], byte[]> record;
+
+        if (partitionKey != null) {
+          // TODO: Support serializing based on key data type instead of using hashcode (e.g. StringSerializer for Strings)
+          final int h = partitionKey.hashCode();
+          final byte[] key = new byte[]{
+                  (byte) (h >>> 24),
+                  (byte) (h >>> 16),
+                  (byte) (h >>> 8),
+                  (byte) h
+          };
+          record = new ProducerRecord<byte[], byte[]>(
+                  destination.getName(),
+                  key,
+                  bb.array());
+        } else {
+          record = new ProducerRecord<byte[], byte[]>(
+                  destination.getName(),
+                  bb.array());
+        }
+
+        producer.send(record, completionCallback);
       }
     }
 

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
@@ -42,7 +42,15 @@ class KafkaOutboundTransportDefinition extends TransportDefinitionBase {
       propertyDefinitions.put("bootstrap", new PropertyDefinition("bootstrap", PropertyType.String, "localhost:9092", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_LBL}", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_DESC}", true, false));
       propertyDefinitions.put("topic", new PropertyDefinition("topic", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.TOPIC_LBL}", "${com.esri.geoevent.transport.kafka-transport.TOPIC_DESC}", true, false));
       propertyDefinitions.put("partitions", new PropertyDefinition("partitions", PropertyType.Integer, "1", "${com.esri.geoevent.transport.kafka-transport.PARTITIONS_LBL}", "${com.esri.geoevent.transport.kafka-transport.PARTITIONS_DESC}", true, false));
-      propertyDefinitions.put("replicas", new PropertyDefinition("replicas", PropertyType.Integer, "0", "${com.esri.geoevent.transport.kafka-transport.REPLICAS_LBL}", "${com.esri.geoevent.transport.kafka-transport.REPLICAS_DESC}", true, false));
+      propertyDefinitions.put("replicas", new PropertyDefinition("replicas", PropertyType.Integer, "1","${com.esri.geoevent.transport.kafka-transport.REPLICAS_LBL}","${com.esri.geoevent.transport.kafka-transport.REPLICAS_DESC}",true,false));
+      propertyDefinitions.put("partitionKeyTag",
+              new PropertyDefinition(
+                      "partitionKeyTag",
+                      PropertyType.String,"",
+                      "${com.esri.geoevent.transport.kafka-transport.PARTITION_KEY_TAG_LBL}",
+                      "${com.esri.geoevent.transport.kafka-transport.PARTITION_KEY_TAG_DESC}",
+                      false,
+                      false));
     }
     catch (PropertyException e)
     {

--- a/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-transport.properties
+++ b/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-transport.properties
@@ -23,6 +23,8 @@ PARTITIONS_LBL=Number Of Partitions
 PARTITIONS_DESC=Default number of partitions per topic.
 REPLICAS_LBL=Replication Factor
 REPLICAS_DESC=Default replication factors for automatically created topics.
+PARTITION_KEY_TAG_LBL=Partition Key Tag
+PARTITION_KEY_TAG_DESC=GeoEvent Tag to use as partition key. Leave empty to use round-robin partitioning.
 
 # Log Messages
 ZKCONNECT_VALIDATE_ERROR=Zookeeper connection string is invalid
@@ -31,3 +33,6 @@ TOPIC_VALIDATE_ERROR=Topic name is invalid
 GROUP_ID_VALIDATE_ERROR=Group Id is invalid
 NUM_THREADS_VALIDATE_ERROR=Number of worker threads in the broker to serve requests is invalid
 KAFKA_SEND_FAILURE_ERROR=Failed to send a message to Apache Kafka
+CONSUMER_RECOVERY_FAILED=Consumer from channel({0}) failed recovering. Error: {1}.
+NO_MATCHING_TAG_WARNING=Cannot partition by key! GeoEvent definition {0} has no matching tag {1}. Using round-robin.
+KAFKA_SENT_RECORD_DEBUG=Sent record: [ topic={0}, partition={1}, offset={2}, keySize={3}, valSize={4} ]

--- a/kafka-transport/src/main/resources/connectors.xml
+++ b/kafka-transport/src/main/resources/connectors.xml
@@ -14,6 +14,7 @@
                 <advanced>
                     <property default="1" label="Number Of Partitions" name="partitions" source="transport"/>
                     <property default="0" label="Replication Factor" name="replicas" source="transport"/>
+                    <property default="" label="Partition Key Tag" name="partitionKeyTag" source="transport"/>
                     <property default="\n" label="Event Separator" name="MessageSeparator" source="adapter"/>
                     <property default="," label="Field Separator" name="AttributeSeparator" source="adapter"/>
                     <property default="text/plain" label="MIME Type" name="mimeType" source="adapter"/>

--- a/kafka-transport/src/main/resources/output-connector-definition.xml
+++ b/kafka-transport/src/main/resources/output-connector-definition.xml
@@ -11,6 +11,7 @@
 		</shown>
 		<advanced>
 			<property default="1" label="Number of Partitions" name="partitions" source="transport"/>
+			<property default="" label="Partition Key Tag" name="partitionKeyTag" source="transport"/>
 			<property default="1" label="Replication Factor" name="replicas" source="transport"/>
 			<property default="\n" label="Event Separator" name="MessageSeparator" source="adapter"/>
 			<property default="," label="Field Separator" name="AttributeSeparator" source="adapter"/>


### PR DESCRIPTION
- Added optional support for partitioning using a GeoEvent tag as the Producer key
- Typical tag used is TRACK_ID, for supporting stateful processing for each track.
- Default value is empty string (Kafka round robin partitioning) to preserve backwards compatibility.
- Added transport property called "Geoevent Key Tag" to support tag designation.

(This PR was resubmitted as a branch feature instead of an update to master)