### PR TITLE
Removed topic creation and deletion from the Kafka Outbound Transport

### DIFF
--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
@@ -38,11 +38,8 @@ class KafkaOutboundTransportDefinition extends TransportDefinitionBase {
   KafkaOutboundTransportDefinition() {
     super(TransportType.OUTBOUND);
     try {
-      propertyDefinitions.put("zkConnect", new PropertyDefinition("zkConnect", PropertyType.String, "localhost:2181", "${com.esri.geoevent.transport.kafka-transport.ZKCONNECT_LBL}", "${com.esri.geoevent.transport.kafka-transport.ZKCONNECT_DESC}", true, false));
-      propertyDefinitions.put("bootstrap", new PropertyDefinition("bootstrap", PropertyType.String, "localhost:9092", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_LBL}", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_DESC}", true, false));
-      propertyDefinitions.put("topic", new PropertyDefinition("topic", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.TOPIC_LBL}", "${com.esri.geoevent.transport.kafka-transport.TOPIC_DESC}", true, false));
-      propertyDefinitions.put("partitions", new PropertyDefinition("partitions", PropertyType.Integer, "1", "${com.esri.geoevent.transport.kafka-transport.PARTITIONS_LBL}", "${com.esri.geoevent.transport.kafka-transport.PARTITIONS_DESC}", true, false));
-      propertyDefinitions.put("replicas", new PropertyDefinition("replicas", PropertyType.Integer, "0", "${com.esri.geoevent.transport.kafka-transport.REPLICAS_LBL}", "${com.esri.geoevent.transport.kafka-transport.REPLICAS_DESC}", true, false));
+        propertyDefinitions.put("bootstrap", new PropertyDefinition("bootstrap", PropertyType.String, "localhost:9092", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_LBL}", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_DESC}", true, false));
+        propertyDefinitions.put("topic", new PropertyDefinition("topic", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.TOPIC_LBL}", "${com.esri.geoevent.transport.kafka-transport.TOPIC_DESC}", true, false));
     }
     catch (PropertyException e)
     {

--- a/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-transport.properties
+++ b/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-transport.properties
@@ -19,10 +19,6 @@ NUM_THREADS_DESC=Controls the number of worker threads in the broker to serve re
 OUT_LABEL=Apache Kafka Outbound Transport
 OUT_DESC=JMS Outbound Transport for connecting to Apache Kafka message servers.
 TRANSPORT_OUT_INIT_ERROR=Failed to define properties of Apache Kafka outbound transport. Error: {0}.
-PARTITIONS_LBL=Number Of Partitions
-PARTITIONS_DESC=Default number of partitions per topic.
-REPLICAS_LBL=Replication Factor
-REPLICAS_DESC=Default replication factors for automatically created topics.
 
 # Log Messages
 ZKCONNECT_VALIDATE_ERROR=Zookeeper connection string is invalid

--- a/kafka-transport/src/main/resources/connectors.xml
+++ b/kafka-transport/src/main/resources/connectors.xml
@@ -12,8 +12,6 @@
             <description>Publishes GeoEvents as text to Apache Kafka.</description>
             <properties>
                 <advanced>
-                    <property default="1" label="Number Of Partitions" name="partitions" source="transport"/>
-                    <property default="0" label="Replication Factor" name="replicas" source="transport"/>
                     <property default="\n" label="Event Separator" name="MessageSeparator" source="adapter"/>
                     <property default="," label="Field Separator" name="AttributeSeparator" source="adapter"/>
                     <property default="text/plain" label="MIME Type" name="mimeType" source="adapter"/>
@@ -23,9 +21,8 @@
                 </advanced>
                 <hidden/>
                 <shown>
-                    <property default="localhost:2181" label="Zookeeper Connection String" name="zkConnect" source="transport"/>
                     <property default="localhost:9092" label="Bootstrap Servers" name="bootstrap" source="transport"/>
-                    <property label="Topic Name" name="topic" source="transport"/>
+                    <property label="Topic Name (Existing)" name="topic" source="transport"/>
                 </shown>
             </properties>
             <transport uri="com.esri.geoevent.transport.outbound/Kafka/10.5.0"/>

--- a/kafka-transport/src/main/resources/output-connector-definition.xml
+++ b/kafka-transport/src/main/resources/output-connector-definition.xml
@@ -5,13 +5,10 @@
 	<transport uri="com.esri.ges.transport.outbound/Kafka/10.5.0"/>
 	<properties>
 		<shown>
-			<property default="localhost:2181" label="Zookeeper Connection String" name="zkConnect" source="transport"/>
 			<property default="localhost:9092" label="Bootstrap Servers" name="bootstrap" source="transport"/>
-			<property label="Topic Name" name="topic" source="transport"/>
+			<property label="Topic Name (Existing)" name="topic" source="transport"/>
 		</shown>
 		<advanced>
-			<property default="1" label="Number of Partitions" name="partitions" source="transport"/>
-			<property default="1" label="Replication Factor" name="replicas" source="transport"/>
 			<property default="\n" label="Event Separator" name="MessageSeparator" source="adapter"/>
 			<property default="," label="Field Separator" name="AttributeSeparator" source="adapter"/>
 			<property default="text/plain" label="MIME Type" name="mimeType" source="adapter"/>


### PR DESCRIPTION
Fixes [Issue #14](https://github.com/Esri/kafka-for-geoevent/issues/14). 

NOTE: This is a breaking change for existing clients relying on the transport for ZK deletion/publishing behavior. However, as noted in [Issue #14](https://github.com/Esri/kafka-for-geoevent/issues/14) the current behavior is not recommended for production environments.

- Removes topic creation and deletion in the Kafka Outbound Transport. Administrative functions are better handled outside the component via the Kafka CLI, or Zookeeper API. 
- Removes related Kafka Outbound Transport properties: `zkConnect`, `partitions` and `replicas`.

(Updated PR as a branch feature containing only updates for this single issue.)